### PR TITLE
Update : reset 로직 작성 #49

### DIFF
--- a/src/ranking/entities/ranking.entity.ts
+++ b/src/ranking/entities/ranking.entity.ts
@@ -2,10 +2,7 @@ import {
   Column,
   Entity,
   JoinColumn,
-  ManyToMany,
   ManyToOne,
-  OneToMany,
-  OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { Category } from 'src/category/entities/category.entity';

--- a/src/ranking/ranking.controller.ts
+++ b/src/ranking/ranking.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
+import { Controller, Delete, Get, Query, UseGuards } from '@nestjs/common';
 import { AuthGuard } from 'src/guards/auth.guard';
 import { User } from 'src/user/entities/user.entity';
 import { RankingService } from './ranking.service';
@@ -12,5 +12,10 @@ export class RankingController {
   @Get('')
   ranking(@Query('category') category: string, @CurrentUser() user: User) {
     return this.rankingService.ranking(category, user);
+  }
+
+  @Delete('/reset')
+  resetRanking(@CurrentUser() user: User) {
+    return this.rankingService.resetRanking(user);
   }
 }

--- a/src/ranking/ranking.service.ts
+++ b/src/ranking/ranking.service.ts
@@ -39,14 +39,14 @@ export class RankingService {
       },
     });
 
-    const {max: maxCategory} = await this.repo
+    const { max: maxCategory } = await this.repo
       .createQueryBuilder('ranking')
       .select('MAX(ranking.time)', 'max')
       .leftJoin('ranking.category', 'category')
       .where('category.name = :category', { category })
-      .getRawOne()
+      .getRawOne();
 
-    const {min: minCategory} = await this.repo
+    const { min: minCategory } = await this.repo
       .createQueryBuilder('ranking')
       .select('MIN(ranking.time)', 'min')
       .leftJoin('ranking.category', 'category')
@@ -109,5 +109,15 @@ export class RankingService {
   @Cron('0 0 5 * * 1')
   private async deleteRank() {
     return await this.repo.clear();
+  }
+
+  async resetRanking(user: User) {
+    const { id: userId } = user;
+    return await this.repo
+      .createQueryBuilder()
+      .delete()
+      .from('ranking')
+      .where('user = :id', { userId })
+      .execute();
   }
 }

--- a/src/timer/focus.service.ts
+++ b/src/timer/focus.service.ts
@@ -58,4 +58,14 @@ export class FocusService {
       .execute();
     console.log('updated monthly focus time');
   }
+
+  async resetFocus(user: User) {
+    const { id: userId } = user;
+    await this.repo
+      .createQueryBuilder()
+      .delete()
+      .from('totalfocustime')
+      .where('user = :id', { userId })
+      .execute();
+  }
 }

--- a/src/timer/rest.service.ts
+++ b/src/timer/rest.service.ts
@@ -59,7 +59,7 @@ export class RestService {
     console.log('updated monthly rest time');
   }
 
-  async resetFocus(user: User) {
+  async resetRest(user: User) {
     const { id: userId } = user;
     await this.repo
       .createQueryBuilder()

--- a/src/timer/rest.service.ts
+++ b/src/timer/rest.service.ts
@@ -58,4 +58,14 @@ export class RestService {
       .execute();
     console.log('updated monthly rest time');
   }
+
+  async resetFocus(user: User) {
+    const { id: userId } = user;
+    await this.repo
+      .createQueryBuilder()
+      .delete()
+      .from('totalresttime')
+      .where('user = :id', { userId })
+      .execute();
+  }
 }

--- a/src/timer/timer.controller.ts
+++ b/src/timer/timer.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, Get, Patch, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Patch,
+  UseGuards,
+} from '@nestjs/common';
 import { TimerService } from './timer.service';
 import { User } from 'src/user/entities/user.entity';
 import { CurrentUser } from 'src/user/decorators/current-user.decorator';
@@ -7,29 +14,26 @@ import { UpdateFocusDto } from './dto/update-focus.dto';
 import { UpdateRestDto } from './dto/update-rest-dto';
 
 @Controller('api/timer')
+@UseGuards(AuthGuard)
 export class TimerController {
   constructor(private timerService: TimerService) {}
 
   @Get('total_focus')
-  @UseGuards(AuthGuard)
   getTotalFocusTime(@CurrentUser() user: User) {
     return this.timerService.getTotalFocusTime(user);
   }
 
   @Get('total_rest')
-  @UseGuards(AuthGuard)
   getTotalRestTime(@CurrentUser() user: User) {
     return this.timerService.getTotalRestTime(user);
   }
 
   @Get('progress')
-  @UseGuards(AuthGuard)
   getProgress(@CurrentUser() user: User) {
     return this.timerService.getProgress(user);
   }
 
   @Patch('total_focus')
-  @UseGuards(AuthGuard)
   updateTotalFocusTime(
     @Body() focusData: UpdateFocusDto,
     @CurrentUser() user: User,
@@ -38,11 +42,15 @@ export class TimerController {
   }
 
   @Patch('total_rest')
-  @UseGuards(AuthGuard)
   updateTotalRestTime(
     @Body() restData: UpdateRestDto,
     @CurrentUser() user: User,
   ) {
     return this.timerService.updateRestTime(restData.addRestTime, user);
+  }
+
+  @Delete('/reset')
+  resetTimer(@CurrentUser() user: User) {
+    return this.timerService.resetTimer(user);
   }
 }

--- a/src/timer/timer.service.ts
+++ b/src/timer/timer.service.ts
@@ -75,6 +75,6 @@ export class TimerService {
 
   resetTimer(user: User) {
     this.focusService.resetFocus(user);
-    this.restService.resetFocus(user);
+    this.restService.resetRest(user);
   }
 }

--- a/src/timer/timer.service.ts
+++ b/src/timer/timer.service.ts
@@ -72,4 +72,9 @@ export class TimerService {
     await this.focusService.updateMonth();
     await this.restService.updateMonth();
   }
+
+  resetTimer(user: User) {
+    this.focusService.resetFocus(user);
+    this.restService.resetFocus(user);
+  }
 }

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -19,32 +19,29 @@ import { UpdateTodoDto } from './dto/update-todo.dto';
 import { TodoService } from './todo.service';
 
 @Controller('api/todos')
+@UseGuards(AuthGuard)
 export default class TodoController {
   constructor(private todoService: TodoService) {}
 
   @Post('/')
-  @UseGuards(AuthGuard)
   async addTodo(@Body() todoData: AddTodoDto, @CurrentUser() userdata: User) {
     await this.todoService.addTodo(todoData, userdata);
     return 'Successfully created a todo';
   }
 
   @Get('/:id')
-  @UseGuards(AuthGuard)
   async getOneTodo(@Param('id') todoId: number, @CurrentUser() userdata: User) {
     const todo = await this.todoService.getOneTodo(todoId, userdata);
     return todo;
   }
 
   @Delete('/:id')
-  @UseGuards(AuthGuard)
   async deleteTodo(@Param('id') todoId: number, @CurrentUser() userdata: User) {
     return this.todoService.deleteTodo(todoId, userdata);
   }
 
   @Patch('/:id')
   @Serialize(TodoDto)
-  @UseGuards(AuthGuard)
   async updateTodo(
     @Param('id') todoId: number,
     @Body() updateData: UpdateTodoDto,
@@ -55,14 +52,17 @@ export default class TodoController {
 
   @Patch('/:id/done')
   @Serialize(TodoDto)
-  @UseGuards(AuthGuard)
   async doTodo(@Param('id') todoId: number, @CurrentUser() userdata: User) {
     return this.todoService.doTodo(todoId, userdata);
   }
 
   @Get('/')
-  @UseGuards(AuthGuard)
   getList(@Query('done') isDone: boolean, @CurrentUser() userdata: User) {
     return this.todoService.getList(isDone, userdata);
+  }
+
+  @Delete('/reset')
+  resetTodos(@CurrentUser() user: User) {
+    return this.todoService.resetTodos(user);
   }
 }

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -14,7 +14,7 @@ import { Todo } from './entities/todo.entity';
 import { RankingService } from 'src/ranking/ranking.service';
 import { Cron } from '@nestjs/schedule';
 
-const MAX_CATEGORY_LENGTH = 5
+const MAX_CATEGORY_LENGTH = 5;
 @Injectable()
 export class TodoService {
   constructor(
@@ -24,8 +24,10 @@ export class TodoService {
   ) {}
 
   async addTodo(addTodoDto: AddTodoDto, user: User) {
-    if(addTodoDto.categories.length > MAX_CATEGORY_LENGTH){
-      throw new BadRequestException(`등록 가능한 카테고리 개수 ${MAX_CATEGORY_LENGTH}개를 초과했습니다.`)
+    if (addTodoDto.categories.length > MAX_CATEGORY_LENGTH) {
+      throw new BadRequestException(
+        `등록 가능한 카테고리 개수 ${MAX_CATEGORY_LENGTH}개를 초과했습니다.`,
+      );
     }
     const categories = await this.categoryService.findOrCreateCategories(
       addTodoDto.categories,
@@ -61,8 +63,10 @@ export class TodoService {
     if (!todo) {
       throw new NotFoundException('Todo not found');
     }
-    if(updateTodo.categories.length > MAX_CATEGORY_LENGTH){
-      throw new BadRequestException(`등록 가능한 카테고리 개수 ${MAX_CATEGORY_LENGTH}개를 초과했습니다.`)
+    if (updateTodo.categories.length > MAX_CATEGORY_LENGTH) {
+      throw new BadRequestException(
+        `등록 가능한 카테고리 개수 ${MAX_CATEGORY_LENGTH}개를 초과했습니다.`,
+      );
     }
     if (updateTodo?.categories) {
       const newCategories = await this.categoryService.findOrCreateCategories(
@@ -104,5 +108,15 @@ export class TodoService {
       .where('todo.date < :date', { date: new Date() })
       .getRawMany();
     return await this.repo.remove(staleTodos);
+  }
+
+  async resetTodos(user: User) {
+    const { id: userId } = user;
+    return await this.repo
+      .createQueryBuilder()
+      .delete()
+      .from('todo')
+      .where('user = :id', { userId })
+      .execute();
   }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,11 +1,13 @@
 import {
   Controller,
+  Delete,
   Get,
   NotFoundException,
   Param,
   Post,
   Query,
   Redirect,
+  UseGuards,
 } from '@nestjs/common';
 import { Serialize } from 'src/interceptor/serialize.interceptor';
 import { AuthService } from './auth.service';
@@ -13,6 +15,7 @@ import { CurrentUser } from './decorators/current-user.decorator';
 import { UserDto } from './dto/user.dto';
 import { User } from './entities/user.entity';
 import { UserService } from './user.service';
+import { AuthGuard } from 'src/guards/auth.guard';
 
 @Controller('/api/users')
 export class UserController {


### PR DESCRIPTION
todo, ranking, timer(focus, rest)에 특정 유저관련 데이터 reset 로직 추가

# createQueryBuilder
위 메소드를 사용해서 총 4군데(todo, ranking, focus, rest) 컨트롤러, 서비스에 reset 로직을 추가했습니다. 찾아보면서 한다고 했지만, SQL 부분에서는 희정님의 확인이 꼭 필요할 거 같아서 희정님의 꼼꼼한 리뷰 부탁드리겠습니다.
사실 각각의 로직은 똑같습니다. 그래서 한 두 개 확인해 주시면 될 거 같습니다.

# UseGuards
몇몇 controller 파일에서 해당 클래스의 모든 메소드에 위 데코레이터를 달고 있더라고요. 사실 그러면 전체 클래스에 데코레이터를 다는 것이 더 나으니까 그렇게 수정했습니다.
그 외 눈에 보이는 몇몇 안쓰는 Import 문 정리했습니다.