### PR TITLE
Hotfix/103 removetodosbeforedate 리펙토링 하기

### DIFF
--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -90,12 +90,12 @@ export default class TodoController {
   }
 
   @Delete('/')
-  async removeTodosBeforeDate(
+  async removeDidntDo(
     @CurrentUser() userdata: User,
     @Query('currentDate') currentDate: string,
     // TODO : 고려할 점: 사용자가 date를 임의로 넣어서 api요청을 하는 경우를 막을 수 없음.
   ) {
-    await this.todoService.removeTodosBeforeDate(currentDate, userdata);
+    await this.todoService.removeDidntDo(currentDate, userdata);
     return 'Successfully removed todos before today';
   }
 }

--- a/src/todo/todo.service.spec.ts
+++ b/src/todo/todo.service.spec.ts
@@ -239,4 +239,11 @@ describe('TodoService', () => {
       expect(result).toBe(undefined);
     });
   });
+
+  describe('getPast2Months', () => {
+    it('should return string that represent first day of 2 months ago', () => {
+      const result = service.getPast2Months('2024-08-15T15:00:00Z');
+      expect(result).toBe('2024-06-01');
+    });
+  });
 });

--- a/src/todo/todo.service.spec.ts
+++ b/src/todo/todo.service.spec.ts
@@ -204,10 +204,15 @@ describe('TodoService', () => {
         (todo) => todo.user.id === fakeUserHas5Todos.id && todo.order > 2,
       );
     });
-    it('should take out order', () => {
+    it('should subtract order just one if we didn‘t pass the second parameter', () => {
       const minus = service.minusOrder(todos);
       expect(minus[0].order).toEqual(2);
       expect(minus[1].order).toEqual(3);
+    });
+    it('should subtract order as much as we pass to the second parameter', () => {
+      const minus = service.minusOrder(todos, 2);
+      expect(minus[0].order).toEqual(1);
+      expect(minus[1].order).toEqual(2);
     });
     it('should return empty array when empty array comes to param', () => {
       const result = service.minusOrder([]);

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -93,9 +93,9 @@ export class TodoService {
   async removeTodoOrder(todoOrder: number, userId: number): Promise<Todo[]> {
     const todos = await this.repo
       .createQueryBuilder('todo')
-      .select('*')
-      .where('todo.order > :todoOrder', { todoOrder })
-      .andWhere('todo.userId = :userId', { userId })
+      .select()
+      .where('todo.userId = :userId', { userId })
+      .andWhere('todo.order > :todoOrder', { todoOrder })
       .orderBy({ 'todo.order': 'ASC' })
       .getMany();
 

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -119,10 +119,10 @@ export class TodoService {
     return this.repo.remove(todo);
   }
 
-  minusOrder(todos: Todo[]): Todo[] {
+  minusOrder(todos: Todo[], operand: number = 1): Todo[] {
     if (todos.length === 0) return [];
     return todos.map((todo) => {
-      todo.order -= 1;
+      todo.order -= operand;
       return todo;
     });
   }

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -252,6 +252,23 @@ export class TodoService {
     return await this.repo.remove(staleTodos);
   }
 
+  /**
+   * @param currentDate 프론트엔드에서 ISO 형식, 즉 2024-08-14T15:00:00.000Z 형태로 보내준다.
+   * 날짜의 2달 전 1일 날짜를 연.월.일 형식으로 계산해 준다.
+   * @returns
+   */
+  getPast2Months(currentDate: string) {
+    const today = new Date(currentDate);
+    const thisMonth = today.getMonth();
+    const thisYear = today.getFullYear();
+
+    const past2Month = String(
+      (thisMonth - 2 < 0 ? thisMonth - 2 + 12 : thisMonth - 2) + 1,
+    ).padStart(2, '0');
+    const pastYear = thisMonth - 2 < 0 ? thisYear - 1 : thisYear;
+    return `${pastYear}-${past2Month}-01`;
+  }
+
   async resetTodos(user: User) {
     const { id: userId } = user;
     const { affected } = await this.repo


### PR DESCRIPTION
- 상세한 내용은 개별 커밋 메시지를 참고해주시면 됩니다 :)

- 계산 메서드에 대해서는 테스트 코드를 작성했지만, 액션 메서드에 대해서는 테스트 코드를 작성하지 않았습니다. 그래도 테스트 과정은 필요해서 로컬 머신에서 mysql로 진행했고 결과 공유드립니다.

- 먼저 테스트 데이터 입니다.
<img width="1337" alt="prev" src="https://github.com/user-attachments/assets/2cde3c44-ce1d-49db-8a10-c7f076da679b">

<br/>
<br/>

- 아래는 유저가 새벽 5시를 기준으로 하루에 딱 한 번 호출하도록 되어있는 'removeDidntDo' 메서드를 호출한 결과 입니다.
  - 2024-08-14T15:00:00Z (한국시간 2024-08-15 00:00:00)으로 호출했습니다.
  - 예상 결과는 오늘 이전의 todo 중 done이 false인 5개의 todo가 삭제되어야 합니다.
  - 또 삭제된 todo만큼 나머지 todo의 order값이 조정되어야 합니다.
<img width="1347" alt="removeDidntDo" src="https://github.com/user-attachments/assets/69256235-4a42-42d9-bfd0-c4a7bc81d4c9">

<br/>
<br/>

- 그 다음 Cron으로 매달 1일에 호출되어야 하는 'removeTodosBeforeOver2Months' 메서드를 호출한 결과입니다.
  - 2024-08-14T15:00:00Z 기준으로 2달전 1일, 즉 6월 1일 이전 데이터가 삭제되어야 합니다.
  - 예상 결과는 6월 1일 이전 데이터 중 done이 true인 1개의 todo가 삭제되어야 합니다.
<img width="1333" alt="removeTodosBeforeOver2Months" src="https://github.com/user-attachments/assets/5d30522f-c16b-4b6e-b09f-6fe08659ab9c">

<br/>
<br/>

질문, 개선사항, 추가 의견 있으시면 편하게 코멘트 남겨주세요 :)