### PR TITLE
108 누락된 setting category remove 메서드 추가

### DIFF
--- a/src/setting/mock-setting.repository.ts
+++ b/src/setting/mock-setting.repository.ts
@@ -1,4 +1,9 @@
-import { DeepPartial, FindOneOptions, SaveOptions } from 'typeorm';
+import {
+  DeepPartial,
+  FindOneOptions,
+  RemoveOptions,
+  SaveOptions,
+} from 'typeorm';
 import { Setting } from './entities/setting.entity';
 
 export const mockSettingRepo = {
@@ -10,5 +15,8 @@ export const mockSettingRepo = {
   },
   findOne(options: FindOneOptions<Setting>) {
     return { id: 1, colorMode: 'auto', extremeMode: true } as Setting;
+  },
+  remove(entity: Setting, options?: RemoveOptions) {
+    return Promise.resolve();
   },
 };

--- a/src/setting/setting.service.spec.ts
+++ b/src/setting/setting.service.spec.ts
@@ -42,7 +42,7 @@ describe('SettingService', () => {
     it('다크 모드, 익스트림모드 on', async () => {
       const currMode = await service.update(fakeUser, {
         colorMode: 'dark',
-        extremeMode: true
+        extremeMode: true,
       });
       expect(currMode.colorMode).toEqual('dark');
       expect(currMode.extremeMode).toEqual(true);
@@ -50,7 +50,7 @@ describe('SettingService', () => {
     it('라이트모드, 익스트림모드 off', async () => {
       const currMode = await service.update(fakeUser, {
         colorMode: 'light',
-        extremeMode: false
+        extremeMode: false,
       });
       expect(currMode.colorMode).toEqual('light');
       expect(currMode.extremeMode).toEqual(false);
@@ -58,7 +58,7 @@ describe('SettingService', () => {
     it('자동색상, 익스트림모드 on', async () => {
       const currMode = await service.update(fakeUser, {
         colorMode: 'auto',
-        extremeMode: true
+        extremeMode: true,
       });
       expect(currMode.colorMode).toEqual('auto');
       expect(currMode.extremeMode).toEqual(true);
@@ -75,6 +75,18 @@ describe('SettingService', () => {
       const currMode = await service.reset(fakeUser);
       expect(currMode.extremeMode).toEqual(true);
       expect(currMode.colorMode).toEqual('auto');
+    });
+  });
+
+  describe('설정삭제', () => {
+    it('설정 데이터 추가', async () => {
+      const currMode = await service.init(fakeUser);
+      expect(currMode.extremeMode).toEqual(true);
+      expect(currMode.colorMode).toEqual('auto');
+    });
+    it('설정삭제', async () => {
+      fakeSettingRepo.findOne = () => undefined;
+      await expect(service.remove(fakeUser)).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/src/setting/setting.service.ts
+++ b/src/setting/setting.service.ts
@@ -36,4 +36,9 @@ export class SettingService {
     setting.extremeMode = data.extremeMode;
     return await this.repo.save(setting);
   }
+
+  async remove(user: User): Promise<void> {
+    const setting = await this.find(user);
+    await this.repo.remove(setting);
+  }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -37,5 +37,6 @@ export class UserService {
 
   async removeUser(user: User) {
     await this.repo.remove(user);
+    await this.settingService.remove(user);
   }
 }


### PR DESCRIPTION
- 빠진 메서드가 있어서 추가했습니다.
- 특히나 유저가 탈퇴할 때 setting 데이터도 삭제가 되어야 하는데 그 부분이 없어서 추가했습니다.
- 혹시 원래 remove가 필요가 없었다면 코멘트 남겨주세요 :)